### PR TITLE
Add CPU opponent option for second player

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
     </div>
   </div>
   <canvas id="game" width="960" height="540"></canvas>
-  <script src="main.js"></script>
+  <div id="modeSelect">
+    <button id="btnP2">2Pと対戦</button>
+    <button id="btnCPU">CPUと対戦</button>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -10,3 +10,5 @@ body { margin: 0; background:#111; color:#eee; font-family: system-ui, sans-seri
 #announce { position:absolute; top:45%; left:50%; transform:translate(-50%,-50%); font-size:48px; font-weight:900; text-shadow:0 2px 8px #000; opacity:0; transition:opacity .2s; }
 .help { position:absolute; bottom:8px; left:16px; right:16px; font-size:12px; opacity:.8; }
 #game { display:block; margin:0 auto; background:linear-gradient(#1b2b4a 40%, #3a2a1a 40% 60%, #1a1a1a 60%); border-top:4px solid #000; }
+#modeSelect { position:absolute; inset:0; display:flex; flex-direction:column; justify-content:center; align-items:center; background:rgba(0,0,0,.6); }
+#modeSelect button { margin:8px; padding:12px 24px; font-size:20px; cursor:pointer; }


### PR DESCRIPTION
## Summary
- Allow choosing between human or CPU-controlled second player at startup
- Implement basic CPU AI and mode selection overlay

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689734de4ca08330ad312e8e42b4226c