### PR TITLE
Disable page scrolling on mobile touch

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,6 +7,10 @@ const announceEl = document.getElementById('announce');
 const roundEl = document.getElementById('round');
 const modeSelEl = document.getElementById('modeSelect');
 
+['touchstart','touchmove'].forEach(ev=>{
+  cvs.addEventListener(ev, e=>e.preventDefault(), {passive:false});
+});
+
 const W = cvs.width, H = cvs.height;
 const GRAV = 0.9, FRICTION = 0.82;
 const GROUND_Y = H * 0.60;

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /* ===== style.css ===== */
 * { box-sizing: border-box; }
-body { margin: 0; background:#111; color:#eee; font-family: system-ui, sans-serif; }
+body { margin: 0; background:#111; color:#eee; font-family: system-ui, sans-serif; overflow:hidden; touch-action:none; overscroll-behavior:none; }
 .ui { position: absolute; inset: 0; pointer-events:none; }
 .names { display:flex; justify-content:space-between; padding:8px 16px; font-weight:700; letter-spacing:.5px; }
 #round { opacity:.9 }
@@ -9,6 +9,6 @@ body { margin: 0; background:#111; color:#eee; font-family: system-ui, sans-seri
 .hp { height:100%; width:100%; background:linear-gradient(90deg,#19c37d,#f5d90a); transition:width .15s linear; }
 #announce { position:absolute; top:45%; left:50%; transform:translate(-50%,-50%); font-size:48px; font-weight:900; text-shadow:0 2px 8px #000; opacity:0; transition:opacity .2s; }
 .help { position:absolute; bottom:8px; left:16px; right:16px; font-size:12px; opacity:.8; }
-#game { display:block; margin:0 auto; background:linear-gradient(#1b2b4a 40%, #3a2a1a 40% 60%, #1a1a1a 60%); border-top:4px solid #000; }
+#game { display:block; margin:0 auto; background:linear-gradient(#1b2b4a 40%, #3a2a1a 40% 60%, #1a1a1a 60%); border-top:4px solid #000; touch-action:none; }
 #modeSelect { position:absolute; inset:0; display:flex; flex-direction:column; justify-content:center; align-items:center; background:rgba(0,0,0,.6); }
 #modeSelect button { margin:8px; padding:12px 24px; font-size:20px; cursor:pointer; }


### PR DESCRIPTION
## Summary
- prevent default touch behavior on canvas to stop page scrolling
- add CSS to block mobile overscroll and panning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5468ba488330883b242542ee7481