### PR TITLE
Add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,19 @@
     </div>
   </div>
   <canvas id="game" width="960" height="540"></canvas>
+  <div id="controls" class="controls">
+    <div class="pad">
+      <button class="up" data-btn="up">▲</button>
+      <button class="left" data-btn="left">◀</button>
+      <button class="right" data-btn="right">▶</button>
+      <button class="down" data-btn="down">▼</button>
+    </div>
+    <div class="actions">
+      <button data-btn="lp">LP</button>
+      <button data-btn="hp">HP</button>
+      <button data-btn="plane">PL</button>
+    </div>
+  </div>
   <div id="modeSelect">
     <button id="btnP2">2Pと対戦</button>
     <button id="btnCPU">CPUと対戦</button>

--- a/script.js
+++ b/script.js
@@ -64,6 +64,26 @@ let cpuMode = false;
 addEventListener('keydown', e=>{ in1.onKey(true,e.code); if(!cpuMode) in2.onKey(true,e.code); });
 addEventListener('keyup',   e=>{ in1.onKey(false,e.code); if(!cpuMode) in2.onKey(false,e.code); });
 
+function setupMobileControls(){
+  if(!('ontouchstart' in window)) return;
+  const ctrl=document.getElementById('controls');
+  if(!ctrl) return;
+  ctrl.style.display='block';
+  const map={left:'KeyA', right:'KeyD', up:'KeyW', down:'KeyS', lp:'KeyF', hp:'KeyG', plane:'KeyR'};
+  ctrl.querySelectorAll('button').forEach(btn=>{
+    const act=btn.dataset.btn, code=map[act];
+    const start=e=>{ e.preventDefault(); in1.onKey(true,code); };
+    const end=e=>{ e.preventDefault(); in1.onKey(false,code); };
+    btn.addEventListener('touchstart',start);
+    btn.addEventListener('touchend',end);
+    btn.addEventListener('touchcancel',end);
+    btn.addEventListener('mousedown',start);
+    btn.addEventListener('mouseup',end);
+    btn.addEventListener('mouseleave',end);
+  });
+}
+setupMobileControls();
+
 // ユーティリティ
 function rectsOverlap(a,b){
   return a.x < b.x+b.w && a.x+a.w > b.x && a.y < b.y+b.h && a.y+a.h > b.y;

--- a/style.css
+++ b/style.css
@@ -12,3 +12,22 @@ body { margin: 0; background:#111; color:#eee; font-family: system-ui, sans-seri
 #game { display:block; margin:0 auto; background:linear-gradient(#1b2b4a 40%, #3a2a1a 40% 60%, #1a1a1a 60%); border-top:4px solid #000; touch-action:none; }
 #modeSelect { position:absolute; inset:0; display:flex; flex-direction:column; justify-content:center; align-items:center; background:rgba(0,0,0,.6); }
 #modeSelect button { margin:8px; padding:12px 24px; font-size:20px; cursor:pointer; }
+
+/* Mobile controls */
+#controls { position:absolute; inset:0; display:none; }
+#controls .pad { position:absolute; left:12px; bottom:12px; width:180px; height:180px; }
+#controls .pad button {
+  position:absolute; width:60px; height:60px; border-radius:8px;
+  background:rgba(255,255,255,.1); color:#fff; border:2px solid #666;
+  font-size:24px; opacity:.8;
+}
+#controls .pad .up { left:60px; top:0; }
+#controls .pad .left { left:0; top:60px; }
+#controls .pad .right { left:120px; top:60px; }
+#controls .pad .down { left:60px; top:120px; }
+#controls .actions { position:absolute; right:12px; bottom:12px; display:flex; flex-direction:column; gap:12px; }
+#controls .actions button {
+  width:80px; height:80px; border-radius:50%;
+  background:rgba(255,255,255,.1); color:#fff; border:2px solid #666;
+  font-size:20px; opacity:.8;
+}


### PR DESCRIPTION
## Summary
- Add on-screen directional and action buttons for touch devices
- Style mobile controls for usability and visibility
- Wire touch buttons to existing input system

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5d0656448330bcf573ce94ea2aae